### PR TITLE
Make the RShiny app runnable on Terra

### DIFF
--- a/manninglab-wgs-visualization/appfiles/app.R
+++ b/manninglab-wgs-visualization/appfiles/app.R
@@ -89,7 +89,7 @@ ui <- fluidPage(
 # Server-side code for the app
 server <- function(input, output, session)
 {
-  setwd("/tmp")
+  #setwd("/tmp")
   
   # Toggling the sidebar
   observeEvent(input$toggleSidebar, {
@@ -100,24 +100,6 @@ server <- function(input, output, session)
   observeEvent(input$bucketsubmit, {
     # Closing any alerts that maybe displayed
     closeAlert(session, "errorAlert")
-    
-    # Setting Google credentials to environment variables
-    Sys.setenv(GOOGLE_APPLICATION_CREDENTIALS = "/tmp/application_default_credentials.json") # Used for gcloud functions
-    Sys.setenv(BOTO_PATH = "/tmp/.boto") # Used for gsutil
-    
-    # Generating a .boto file from the application_default_credentials.json file to be used by gsutil
-    js <-
-      fromJSON(file = "/tmp/application_default_credentials.json")
-    boto_data <-
-      paste0(
-        "[OAuth2]\nclient_id = ",
-        js$client_id,
-        "\nclient_secret = ",
-        js$client_secret,
-        "\n\n[Credentials]\ngs_oauth2_refresh_token = ",
-        js$refresh_token
-      )
-    write(boto_data, file = "/tmp/.boto")
     
     # Generating the access token using gcloud to be used by tabix
     write(
@@ -147,7 +129,7 @@ server <- function(input, output, session)
           read.table(pipe(
             # Using gsutil to obtain list of the bucket contents
             paste(
-              "/usr/local/gcloud/google-cloud-sdk/bin/gsutil ls", bucket
+              "gsutil ls", bucket
             )
           )),
           error = function(e){ E <<- "Incorrect bucket link entered"}
@@ -260,7 +242,7 @@ server <- function(input, output, session)
             read.table(pipe(
               # Using gsutil to obtain list of the bucket contents
               paste(
-                "/usr/local/gcloud/google-cloud-sdk/bin/gsutil ls", bucket
+                "gsutil ls", bucket
               )
             )),
             error = function(e){ E <<- "Incorrect bucket link entered"}
@@ -424,7 +406,7 @@ server <- function(input, output, session)
           paste0(
             "export GCS_OAUTH_TOKEN=",
             accesstoken,
-            " ; /usr/local/htslib-1.9/bin/tabix ",
+            " ; tabix ",
             gspath,
             " ",
             input$searchrange

--- a/manninglab-wgs-visualization/appfiles/app.R
+++ b/manninglab-wgs-visualization/appfiles/app.R
@@ -89,8 +89,6 @@ ui <- fluidPage(
 # Server-side code for the app
 server <- function(input, output, session)
 {
-  #setwd("/tmp")
-  
   # Toggling the sidebar
   observeEvent(input$toggleSidebar, {
     shinyjs::toggle(id = "Sidebar")

--- a/manninglab-wgs-visualization/appfiles/functions.R
+++ b/manninglab-wgs-visualization/appfiles/functions.R
@@ -83,7 +83,7 @@ get_tabix_df <- function(file = NULL,
         value = withCallingHandlers(
           tryCatch(
             read.table(pipe(
-              paste("/usr/local/htslib-1.9/bin/tabix", file, searchrange)
+              paste("tabix", file, searchrange)
             ), stringsAsFactors = F),
             error = e.handler
           ),
@@ -138,7 +138,7 @@ var_init <- function(temp, input, output)
     ldpath <- paste0(input$bucket2, "/", isolate(input$ldpath))
     write(system(
       paste(
-        "/usr/local/gcloud/google-cloud-sdk/bin/gsutil cat",
+        "gsutil cat",
         ldpath
       ),
       intern = T


### PR DESCRIPTION
It's up to the maintainers how/whether you want to integrate this, but I thought I'd share my work making this shiny app runnable on RStudio in Terra.

1. Run app from the cwd instead of `/tmp`
2. No need for `credentials.json` or `.boto` files -- Terra handles authentication
3. Remove hard-coded paths to `gsutil` and `tabix`

It seems to work! See this workspace for steps on how to get the app up and running: https://terra.biodatacatalyst.nhlbi.nih.gov/#workspaces/fc-product-demo/2021-06-02_BDCatalyst_June_VQM (ping Rob if you need access).
